### PR TITLE
feat: use network_mode `host` in docker

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -14,17 +14,12 @@ services:
         max-file: "10"
     depends_on:
       - proxy
+    network_mode: host
 
   proxy:
     image: nginx:mainline-alpine
     container_name: proxy
     restart: unless-stopped
-    networks:
-      - frontend_network
-      - backend_network
-    ports:
-      - "80:80"
-      - "443:443"
     volumes:
       - ./storage/proxy/webroot:/var/www/html
       - ./storage/proxy/etc/nginx-conf:/etc/nginx/conf.d
@@ -40,6 +35,7 @@ services:
       - index
       - tracker
       - grafana
+    network_mode: host
 
   index-gui:
     image: torrust/index-gui:develop
@@ -49,12 +45,8 @@ services:
     environment:
       - USER_ID=${USER_ID}
       - NUXT_PUBLIC_API_BASE=${TORRUST_INDEX_GUI_API_BASE_URL:-http://localhost:3001/v1}
-      - NITRO_HOST=${NITRO_HOST:-0.0.0.0}
+      - NITRO_HOST=${NITRO_HOST:-127.0.0.1}
       - NITRO_PORT=${NITRO_PORT:-3000}
-    networks:
-      - frontend_network
-    ports:
-      - 3000:3000
     volumes:
       - ./storage/index-gui/log:/var/log/torrust/index-gui:Z
     logging:
@@ -64,6 +56,7 @@ services:
     depends_on:
       - index
       - tracker
+    network_mode: host
 
   index:
     image: torrust/index:develop
@@ -77,10 +70,6 @@ services:
       - TORRUST_INDEX_CONFIG_OVERRIDE_TRACKER__TOKEN=${TORRUST_INDEX_CONFIG_OVERRIDE_TRACKER__TOKEN:-MyAccessToken}
       - TORRUST_INDEX_CONFIG_OVERRIDE_AUTH__USER_CLAIM_TOKEN_PEPPER=${TORRUST_INDEX_CONFIG_OVERRIDE_AUTH__USER_CLAIM_TOKEN_PEPPER:-MaxVerstappenWC2021}
       - TORRUST_INDEX_API_CORS_PERMISSIVE=${TORRUST_INDEX_API_CORS_PERMISSIVE:-true}
-    networks:
-      - backend_network
-    ports:
-      - 3001:3001
     volumes:
       - ./storage/index/lib:/var/lib/torrust/index:Z
       - ./storage/index/log:/var/log/torrust/index:Z
@@ -91,6 +80,7 @@ services:
         max-file: "10"
     depends_on:
       - tracker
+    network_mode: host
 
   grafana:
     image: grafana/grafana:11.4.0
@@ -99,24 +89,18 @@ services:
     environment:
       - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:-admin}
-    networks:
-      - backend_network
-    ports:
-      - "3100:3000"
+      - GF_SERVER_HTTP_PORT=3100
     volumes:
       - grafana_data:/var/lib/grafana
     depends_on:
       - prometheus
+    network_mode: host
 
   prometheus:
     image: prom/prometheus:v3.0.1
     container_name: prometheus
     tty: true
     restart: unless-stopped
-    networks:
-      - backend_network
-    ports:
-      - "9090:9090" # This port should not be exposed to the internet
     volumes:
       - ./storage/prometheus/etc:/etc/prometheus:Z
     logging:
@@ -125,6 +109,7 @@ services:
         max-file: "10"
     depends_on:
       - tracker
+    network_mode: host
 
   tracker:
     image: torrust/tracker:develop
@@ -136,13 +121,6 @@ services:
       - TORRUST_TRACKER_DATABASE=${TORRUST_TRACKER_DATABASE:-sqlite3}
       - TORRUST_TRACKER_CONFIG_OVERRIDE_CORE__DATABASE__DRIVER=${TORRUST_TRACKER_CONFIG_OVERRIDE_CORE__DATABASE__DRIVER:-sqlite3}
       - TORRUST_TRACKER_CONFIG_OVERRIDE_HTTP_API__ACCESS_TOKENS__ADMIN=${TORRUST_TRACKER_CONFIG_OVERRIDE_HTTP_API__ACCESS_TOKENS__ADMIN:-MyAccessToken}
-    networks:
-      - backend_network
-    ports:
-      - 6868:6868/udp
-      - 6969:6969/udp
-      - 7070:7070
-      - 1212:1212
     volumes:
       - ./storage/tracker/lib:/var/lib/torrust/tracker:Z
       - ./storage/tracker/log:/var/log/torrust/tracker:Z
@@ -151,12 +129,8 @@ services:
       options:
         max-size: "10m"
         max-file: "10"
-
-networks:
-  frontend_network: {}
-  backend_network: {}
+    network_mode: host
 
 volumes:
   mysql_data: {}
   grafana_data: {}
-

--- a/share/container/default/config/index.prod.container.sqlite3.toml
+++ b/share/container/default/config/index.prod.container.sqlite3.toml
@@ -9,7 +9,7 @@ schema_version = "2.0.0"
 threshold = "info"
 
 [tracker]
-api_url = "http://tracker:1212"
+api_url = "http://127.0.0.1:1212"
 listed = false
 private = false
 url = "udp://tracker.torrust-demo.com:6969"

--- a/share/container/default/config/nginx.conf
+++ b/share/container/default/config/nginx.conf
@@ -1,64 +1,64 @@
 server
 {
-    listen 80;
-    listen [::]:80;
+        listen 80;
+        listen [::]:80;
 
-    root /var/www/html;
-    index index.html index.htm index.nginx-debian.html;
+        root /var/www/html;
+        index index.html index.htm index.nginx-debian.html;
 
-    server_name index.torrust-demo.com;
+        server_name index.torrust-demo.com;
 
 	error_log /var/log/nginx/error.log debug;
 
-	location /api/v1/proxy
+	location /api/v1/proxy 
 	{
 		rewrite ^ $request_uri;
 		rewrite ^/api(/.*) $1 break;
-		proxy_pass http://index:3001;
+		proxy_pass http://127.0.0.1:3001;
 	}
 
 	location ^~/api/
 	{
-		proxy_pass http://index:3001/;
+		proxy_pass http://127.0.0.1:3001/;
 	}
 
-    location /
-    {
-        proxy_pass http://index-gui:3000;
-    }
+        location /
+        {
+                proxy_pass http://127.0.0.1:3000;
+        }
 
-    location ~ /.well-known/acme-challenge
-    {
-        allow all;
-        root /var/www/html;
-    }
+        location ~ /.well-known/acme-challenge
+        {
+                allow all;
+                root /var/www/html;
+        }
 }
 
 server
 {
-    listen 80;
-    listen [::]:80;
+        listen 80;
+        listen [::]:80;
 
-    root /var/www/html;
-    index index.html index.htm index.nginx-debian.html;
+        root /var/www/html;
+        index index.html index.htm index.nginx-debian.html;
 
-    server_name tracker.torrust-demo.com;
+        server_name tracker.torrust-demo.com;
 
-    location /api/
-    {
-            proxy_pass http://tracker:1212/api/;
-    }
+        location /api/
+        {
+                proxy_pass http://127.0.0.1:1212/api/;
+        }
 
-    location /
-    {
-            proxy_pass http://tracker:7070;
-    }
+        location /
+        {
+                proxy_pass http://127.0.0.1:7070;
+        }
 
-    location ~ /.well-known/acme-challenge
-    {
-            allow all;
-            root /var/www/html;
-    }
+        location ~ /.well-known/acme-challenge
+        {
+                allow all;
+                root /var/www/html;
+        }
 }
 
 server
@@ -85,32 +85,32 @@ server
 
 #server
 #{
-#    listen 443 ssl http2;
-#    listen [::]:443 ssl http2;
-#    server_name index.torrust-demo.com;
+#        listen 443 ssl http2;
+#        listen [::]:443 ssl http2;
+#        server_name index.torrust-demo.com;
 #
 #	error_log /var/log/nginx/error.log debug;
 #	merge_slashes off;
 #	server_tokens off;
 #
-#    ssl_certificate /etc/letsencrypt/live/index.torrust-demo.com-0001/fullchain.pem;
-#    ssl_certificate_key /etc/letsencrypt/live/index.torrust-demo.com-0001/privkey.pem;
+#        ssl_certificate /etc/letsencrypt/live/index.torrust-demo.com-0001/fullchain.pem;
+#        ssl_certificate_key /etc/letsencrypt/live/index.torrust-demo.com-0001/privkey.pem;
 #
-#    ssl_buffer_size 8k;
+#        ssl_buffer_size 8k;
 #
-#    ssl_dhparam /etc/ssl/certs/dhparam-2048.pem;
+#        ssl_dhparam /etc/ssl/certs/dhparam-2048.pem;
 #
-#    ssl_protocols TLSv1.2;
-#    ssl_prefer_server_ciphers on;
+#        ssl_protocols TLSv1.2;
+#        ssl_prefer_server_ciphers on;
 #
-#    ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
+#        ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
 #
-#    ssl_ecdh_curve secp384r1;
-#    ssl_session_tickets off;
+#        ssl_ecdh_curve secp384r1;
+#        ssl_session_tickets off;
 #
-#    ssl_stapling on;
-#    ssl_stapling_verify on;
-#    resolver 8.8.8.8;
+#        ssl_stapling on;
+#        ssl_stapling_verify on;
+#        resolver 8.8.8.8;
 #
 #	error_log /var/log/nginx/error.log debug;
 #
@@ -127,106 +127,106 @@ server
 #		try_files $uri @index;
 #	}
 #
-#    location /
-#    {
-#            try_files $uri @index-gui;
-#    }
+#        location /
+#        {
+#                try_files $uri @index-gui;
+#        }
 #
-#    location @index
-#    {
-#        proxy_pass http://index:3001;
-#        add_header X-Frame-Options "SAMEORIGIN" always;
-#        add_header X-XSS-Protection "1; mode=block" always;
-#        add_header X-Content-Type-Options "nosniff" always;
-#        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-#        add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
-#        #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-#        # enable strict transport security only if you understand the implications
-#    }
+#        location @index
+#        {
+#                proxy_pass http://127.0.0.1:3001;
+#                add_header X-Frame-Options "SAMEORIGIN" always;
+#                add_header X-XSS-Protection "1; mode=block" always;
+#                add_header X-Content-Type-Options "nosniff" always;
+#                add_header Referrer-Policy "no-referrer-when-downgrade" always;
+#                add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
+#                #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+#                # enable strict transport security only if you understand the implications
+#        }
 #
-#    location @index-gui
-#    {
-#        proxy_pass http://index-gui:3000;
-#        add_header X-Frame-Options "SAMEORIGIN" always;
-#        add_header X-XSS-Protection "1; mode=block" always;
-#        add_header X-Content-Type-Options "nosniff" always;
-#        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-#        add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
-#        #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-#        # enable strict transport security only if you understand the implications
-#    }
+#        location @index-gui
+#        {
+#                proxy_pass http://127.0.0.1:3000;
+#                add_header X-Frame-Options "SAMEORIGIN" always;
+#                add_header X-XSS-Protection "1; mode=block" always;
+#                add_header X-Content-Type-Options "nosniff" always;
+#                add_header Referrer-Policy "no-referrer-when-downgrade" always;
+#                add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
+#                #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+#                # enable strict transport security only if you understand the implications
+#        }
 #
-#    root /var/www/html;
-#    index index.html index.htm index.nginx-debian.html;
+#        root /var/www/html;
+#        index index.html index.htm index.nginx-debian.html;
 #}
-
+#
 #server
 #{
-#    listen 443 ssl http2;
-#    listen [::]:443 ssl http2;
-#    server_name tracker.torrust-demo.com;
+#        listen 443 ssl http2;
+#        listen [::]:443 ssl http2;
+#        server_name tracker.torrust-demo.com;
 #
-#    server_tokens off;
+#        server_tokens off;
 #
-#    ssl_certificate /etc/letsencrypt/live/tracker.torrust-demo.com/fullchain.pem;
-#    ssl_certificate_key /etc/letsencrypt/live/tracker.torrust-demo.com/privkey.pem;
+#        ssl_certificate /etc/letsencrypt/live/tracker.torrust-demo.com/fullchain.pem;
+#        ssl_certificate_key /etc/letsencrypt/live/tracker.torrust-demo.com/privkey.pem;
 #
-#    ssl_buffer_size 8k;
+#        ssl_buffer_size 8k;
 #
-#    ssl_dhparam /etc/ssl/certs/dhparam-2048.pem;
+#        ssl_dhparam /etc/ssl/certs/dhparam-2048.pem;
 #
-#    ssl_protocols TLSv1.2;
-#    ssl_prefer_server_ciphers on;
+#        ssl_protocols TLSv1.2;
+#        ssl_prefer_server_ciphers on;
 #
-#    ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
+#        ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
 #
-#    ssl_ecdh_curve secp384r1;
-#    ssl_session_tickets off;
+#        ssl_ecdh_curve secp384r1;
+#        ssl_session_tickets off;
 #
-#    ssl_stapling on;
-#    ssl_stapling_verify on;
-#    resolver 8.8.8.8;
+#        ssl_stapling on;
+#        ssl_stapling_verify on;
+#        resolver 8.8.8.8;
 #
-#    location /api/
-#    {
-#        try_files $uri @tracker-api;
-#    }
+#        location /api/
+#        {
+#                try_files $uri @tracker-api;
+#        }
 #
-#    location /
-#    {
-#        try_files $uri @tracker-http;
-#    }
+#        location /
+#        {
+#                try_files $uri @tracker-http;
+#        }
 #
-#    location @tracker-api
-#    {
-#        proxy_pass http://tracker:1212;
-#        add_header X-Frame-Options "SAMEORIGIN" always;
-#        add_header X-XSS-Protection "1; mode=block" always;
-#        add_header X-Content-Type-Options "nosniff" always;
-#        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-#        add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
-#        #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-#        # enable strict transport security only if you understand the implications
-#    }
+#        location @tracker-api
+#        {
+#                proxy_pass http://127.0.0.1:1212;
+#                add_header X-Frame-Options "SAMEORIGIN" always;
+#                add_header X-XSS-Protection "1; mode=block" always;
+#                add_header X-Content-Type-Options "nosniff" always;
+#                add_header Referrer-Policy "no-referrer-when-downgrade" always;
+#                add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
+#                #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+#                # enable strict transport security only if you understand the implications
+#        }
 #
-#    location @tracker-http
-#    {
-#        proxy_pass http://tracker:7070;
-#        add_header X-Frame-Options "SAMEORIGIN" always;
-#        add_header X-XSS-Protection "1; mode=block" always;
-#        add_header X-Content-Type-Options "nosniff" always;
-#        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-#        add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
-#        #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-#        # enable strict transport security only if you understand the implications
+#        location @tracker-http
+#        {
+#                proxy_pass http://127.0.0.1:7070;
+#                add_header X-Frame-Options "SAMEORIGIN" always;
+#                add_header X-XSS-Protection "1; mode=block" always;
+#                add_header X-Content-Type-Options "nosniff" always;
+#                add_header Referrer-Policy "no-referrer-when-downgrade" always;
+#                add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
+#                #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+#                # enable strict transport security only if you understand the implications
 #
-#    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-#    }
+#		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#        }
 #
-#    root /var/www/html;
-#    index index.html index.htm index.nginx-debian.html;
+#        root /var/www/html;
+#        index index.html index.htm index.nginx-debian.html;
 #}
-
+#
 ## This is required to proxy Grafana Live WebSocket connections.
 #map $http_upgrade $connection_upgrade {
 #  default upgrade;
@@ -234,7 +234,7 @@ server
 #}
 #
 #upstream grafana {
-#  server grafana:3000;
+#  server 127.0.0.1:3100;
 #}
 #
 #server

--- a/share/container/default/config/nginx.conf.final
+++ b/share/container/default/config/nginx.conf.final
@@ -1,0 +1,283 @@
+server
+{
+        listen 80;
+        listen [::]:80;
+
+        root /var/www/html;
+        index index.html index.htm index.nginx-debian.html;
+
+        server_name index.torrust-demo.com;
+
+	error_log /var/log/nginx/error.log debug;
+
+	location /api/v1/proxy 
+	{
+		rewrite ^ $request_uri;
+		rewrite ^/api(/.*) $1 break;
+		proxy_pass http://127.0.0.1:3001;
+	}
+
+	location ^~/api/
+	{
+		proxy_pass http://127.0.0.1:3001/;
+	}
+
+        location /
+        {
+                proxy_pass http://127.0.0.1:3000;
+        }
+
+        location ~ /.well-known/acme-challenge
+        {
+                allow all;
+                root /var/www/html;
+        }
+}
+
+server
+{
+        listen 80;
+        listen [::]:80;
+
+        root /var/www/html;
+        index index.html index.htm index.nginx-debian.html;
+
+        server_name tracker.torrust-demo.com;
+
+        location /api/
+        {
+                proxy_pass http://127.0.0.1:1212/api/;
+        }
+
+        location /
+        {
+                proxy_pass http://127.0.0.1:7070;
+        }
+
+        location ~ /.well-known/acme-challenge
+        {
+                allow all;
+                root /var/www/html;
+        }
+}
+
+#server
+#{
+#    listen 80;
+#    listen [::]:80;
+#
+#    root /var/www/html;
+#    index index.html index.htm index.nginx-debian.html;
+#
+#    server_name grafana.torrust-demo.com;
+#
+#    location /
+#    {
+#            proxy_pass http://grafana:3000;
+#    }
+#
+#    location ~ /.well-known/acme-challenge
+#    {
+#            allow all;
+#            root /var/www/html;
+#    }
+#}
+
+server
+{
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+        server_name index.torrust-demo.com;
+
+	error_log /var/log/nginx/error.log debug;
+	merge_slashes off;
+	server_tokens off;
+
+        ssl_certificate /etc/letsencrypt/live/index.torrust-demo.com-0001/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/index.torrust-demo.com-0001/privkey.pem;
+
+        ssl_buffer_size 8k;
+
+        ssl_dhparam /etc/ssl/certs/dhparam-2048.pem;
+
+        ssl_protocols TLSv1.2;
+        ssl_prefer_server_ciphers on;
+
+        ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
+
+        ssl_ecdh_curve secp384r1;
+        ssl_session_tickets off;
+
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        resolver 8.8.8.8;
+
+	error_log /var/log/nginx/error.log debug;
+
+	location /api/v1/proxy
+	{
+		rewrite ^ $request_uri;
+		rewrite ^/api(/.*) $1 break;
+		try_files $uri @index;
+	}
+
+	location ^~/api/
+	{
+		rewrite ^/api/(.*)$ /$1 break;
+		try_files $uri @index;
+	}
+
+        location /
+        {
+                try_files $uri @index-gui;
+        }
+
+        location @index
+        {
+                proxy_pass http://127.0.0.1:3001;
+                add_header X-Frame-Options "SAMEORIGIN" always;
+                add_header X-XSS-Protection "1; mode=block" always;
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header Referrer-Policy "no-referrer-when-downgrade" always;
+                add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
+                #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+                # enable strict transport security only if you understand the implications
+        }
+
+        location @index-gui
+        {
+                proxy_pass http://127.0.0.1:3000;
+                add_header X-Frame-Options "SAMEORIGIN" always;
+                add_header X-XSS-Protection "1; mode=block" always;
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header Referrer-Policy "no-referrer-when-downgrade" always;
+                add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
+                #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+                # enable strict transport security only if you understand the implications
+        }
+
+        root /var/www/html;
+        index index.html index.htm index.nginx-debian.html;
+}
+
+server
+{
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+        server_name tracker.torrust-demo.com;
+
+        server_tokens off;
+
+        ssl_certificate /etc/letsencrypt/live/tracker.torrust-demo.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/tracker.torrust-demo.com/privkey.pem;
+
+        ssl_buffer_size 8k;
+
+        ssl_dhparam /etc/ssl/certs/dhparam-2048.pem;
+
+        ssl_protocols TLSv1.2;
+        ssl_prefer_server_ciphers on;
+
+        ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
+
+        ssl_ecdh_curve secp384r1;
+        ssl_session_tickets off;
+
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        resolver 8.8.8.8;
+
+        location /api/
+        {
+                try_files $uri @tracker-api;
+        }
+
+        location /
+        {
+                try_files $uri @tracker-http;
+        }
+
+        location @tracker-api
+        {
+                proxy_pass http://127.0.0.1:1212;
+                add_header X-Frame-Options "SAMEORIGIN" always;
+                add_header X-XSS-Protection "1; mode=block" always;
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header Referrer-Policy "no-referrer-when-downgrade" always;
+                add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
+                #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+                # enable strict transport security only if you understand the implications
+        }
+
+        location @tracker-http
+        {
+                proxy_pass http://127.0.0.1:7070;
+                add_header X-Frame-Options "SAMEORIGIN" always;
+                add_header X-XSS-Protection "1; mode=block" always;
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header Referrer-Policy "no-referrer-when-downgrade" always;
+                add_header Content-Security-Policy "default-src * data: 'unsafe-eval' 'unsafe-inline'" always;
+                #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+                # enable strict transport security only if you understand the implications
+
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        root /var/www/html;
+        index index.html index.htm index.nginx-debian.html;
+}
+
+# This is required to proxy Grafana Live WebSocket connections.
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
+upstream grafana {
+  server 127.0.0.1:3100;
+}
+
+server
+{
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+        server_name grafana.torrust-demo.com;
+
+        server_tokens off;
+
+        ssl_certificate /etc/letsencrypt/live/grafana.torrust-demo.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/grafana.torrust-demo.com/privkey.pem;
+
+        ssl_buffer_size 8k;
+
+        ssl_dhparam /etc/ssl/certs/dhparam-2048.pem;
+
+        ssl_protocols TLSv1.2;
+        ssl_prefer_server_ciphers on;
+
+        ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
+
+        ssl_ecdh_curve secp384r1;
+        ssl_session_tickets off;
+
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        resolver 8.8.8.8;
+
+        location / {
+                proxy_set_header Host $host;
+                proxy_pass http://grafana;
+        }
+
+        # Proxy Grafana Live WebSocket connections.
+        location /api/live/ {
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection $connection_upgrade;
+                proxy_set_header Host $host;
+                proxy_pass http://grafana;
+        }
+
+        root /var/www/html;
+        index index.html index.htm index.nginx-debian.html;
+}

--- a/share/container/default/config/prometheus.yml
+++ b/share/container/default/config/prometheus.yml
@@ -8,7 +8,7 @@ scrape_configs:
       token: ["MyAccessToken"]
       format: ["prometheus"]
     static_configs:
-      - targets: ["tracker:1212"]
+      - targets: ["127.0.0.1:1212"]
 
   - job_name: "tracker_metrics"
     metrics_path: "/api/v1/metrics"
@@ -16,4 +16,4 @@ scrape_configs:
       token: ["MyAccessToken"]
       format: ["prometheus"]
     static_configs:
-      - targets: ["tracker:1212"]
+      - targets: ["127.0.0.1:1212"]


### PR DESCRIPTION
I've changed the network mode for Docker to `host` mode, meaning Docker does not handle the network. Containers use the host network directly.

This was one of the proposals to increase performance.

On the other hand, it appears that we cannot disable connection tracking for UDP within the Docker network. See https://github.com/torrust/torrust-demo/issues/72. This should allow us to disable connection tracking, and that should increase the UDP performance too.