### PR TITLE
Fix metrics dashboard

### DIFF
--- a/share/grafana/dashboards/metrics.json
+++ b/share/grafana/dashboards/metrics.json
@@ -383,7 +383,7 @@
                 {
                     "disableTextWrap": false,
                     "editorMode": "builder",
-                    "expr": "sum(rate(udp_tracker_server_requests_accepted_total{job=\"tracker_metrics\", request_kind=\"connect\"}[15m]))",
+                    "expr": "sum(rate(udp_tracker_server_requests_accepted_total{job=\"tracker_metrics\", request_kind=\"connect\", server_binding_address_ip_family=\"inet\"}[15m]))",
                     "fullMetaSearch": false,
                     "includeNullMetadata": true,
                     "legendFormat": "__auto",
@@ -480,7 +480,7 @@
                 {
                     "disableTextWrap": false,
                     "editorMode": "builder",
-                    "expr": "sum(rate(udp_tracker_server_requests_accepted_total{job=\"tracker_metrics\", request_kind=\"announce\"}[15m]))",
+                    "expr": "sum(rate(udp_tracker_server_requests_accepted_total{job=\"tracker_metrics\", request_kind=\"announce\", server_binding_address_ip_family=\"inet\"}[15m]))",
                     "fullMetaSearch": false,
                     "includeNullMetadata": true,
                     "legendFormat": "__auto",
@@ -577,7 +577,7 @@
                 {
                     "disableTextWrap": false,
                     "editorMode": "builder",
-                    "expr": "sum(rate(udp_tracker_server_requests_accepted_total{job=\"tracker_metrics\", request_kind=\"scrape\"}[15m]))",
+                    "expr": "sum(rate(udp_tracker_server_requests_accepted_total{job=\"tracker_metrics\", request_kind=\"scrape\", server_binding_address_ip_family=\"inet\"}[15m]))",
                     "fullMetaSearch": false,
                     "includeNullMetadata": true,
                     "legendFormat": "__auto",
@@ -674,7 +674,7 @@
                 {
                     "disableTextWrap": false,
                     "editorMode": "builder",
-                    "expr": "sum(rate(udp_tracker_server_errors_total{job=\"tracker_metrics\"}[15m]))",
+                    "expr": "sum(rate(udp_tracker_server_errors_total{job=\"tracker_metrics\", server_binding_address_ip_family=\"inet\"}[15m]))",
                     "fullMetaSearch": false,
                     "includeNullMetadata": true,
                     "legendFormat": "__auto",
@@ -691,7 +691,7 @@
                 "type": "prometheus",
                 "uid": "ce6lwx047kutca"
             },
-            "description": "UDP Average Connect Processing Time",
+            "description": "UDP4 Average Connect Processing Time",
             "fieldConfig": {
                 "defaults": {
                     "color": {
@@ -772,7 +772,7 @@
                 {
                     "disableTextWrap": false,
                     "editorMode": "builder",
-                    "expr": "sum(udp_tracker_server_performance_avg_processing_time_ns{job=\"tracker_metrics\", request_kind=\"connect\"})",
+                    "expr": "avg(udp_tracker_server_performance_avg_processing_time_ns{job=\"tracker_metrics\", request_kind=\"connect\", server_binding_address_ip_family=\"inet\"})",
                     "fullMetaSearch": false,
                     "includeNullMetadata": true,
                     "legendFormat": "__auto",
@@ -781,7 +781,7 @@
                     "useBackend": false
                 }
             ],
-            "title": "UDP Average Connect Time",
+            "title": "UDP4 Average Connect Time",
             "type": "timeseries"
         },
         {
@@ -789,7 +789,7 @@
                 "type": "prometheus",
                 "uid": "ce6lwx047kutca"
             },
-            "description": "UDP Average Announce Processing Time",
+            "description": "UDP4 Average Announce Processing Time",
             "fieldConfig": {
                 "defaults": {
                     "color": {
@@ -870,7 +870,7 @@
                 {
                     "disableTextWrap": false,
                     "editorMode": "builder",
-                    "expr": "sum(udp_tracker_server_performance_avg_processing_time_ns{job=\"tracker_metrics\", request_kind=\"announce\"})",
+                    "expr": "avg(udp_tracker_server_performance_avg_processing_time_ns{job=\"tracker_metrics\", request_kind=\"announce\", server_binding_address_ip_family=\"inet\"})",
                     "fullMetaSearch": false,
                     "includeNullMetadata": true,
                     "legendFormat": "__auto",
@@ -879,7 +879,7 @@
                     "useBackend": false
                 }
             ],
-            "title": "UDP Average Announce Time",
+            "title": "UDP4 Average Announce Time",
             "type": "timeseries"
         },
         {
@@ -887,7 +887,7 @@
                 "type": "prometheus",
                 "uid": "ce6lwx047kutca"
             },
-            "description": "UDP Average Scrape Processing Time",
+            "description": "UDP4 Average Scrape Processing Time",
             "fieldConfig": {
                 "defaults": {
                     "color": {
@@ -968,7 +968,7 @@
                 {
                     "disableTextWrap": false,
                     "editorMode": "builder",
-                    "expr": "sum(udp_tracker_server_performance_avg_processing_time_ns{job=\"tracker_metrics\", request_kind=\"scrape\"})",
+                    "expr": "avg(udp_tracker_server_performance_avg_processing_time_ns{job=\"tracker_metrics\", request_kind=\"scrape\", server_binding_address_ip_family=\"inet\"})",
                     "fullMetaSearch": false,
                     "includeNullMetadata": true,
                     "legendFormat": "__auto",
@@ -977,7 +977,7 @@
                     "useBackend": false
                 }
             ],
-            "title": "UDP Average Scrape Time",
+            "title": "UDP4 Average Scrape Time",
             "type": "timeseries"
         },
         {
@@ -985,7 +985,7 @@
                 "type": "prometheus",
                 "uid": "ce6lwx047kutca"
             },
-            "description": "UDP Banned Requests (per sec)",
+            "description": "UDP4 Banned Requests (per sec)",
             "fieldConfig": {
                 "defaults": {
                     "color": {
@@ -1069,7 +1069,7 @@
                     },
                     "disableTextWrap": false,
                     "editorMode": "builder",
-                    "expr": "sum(rate(udp_tracker_server_requests_banned_total{job=\"tracker_metrics\"}[15m]))",
+                    "expr": "sum(rate(udp_tracker_server_requests_banned_total{job=\"tracker_metrics\", server_binding_address_ip_family=\"inet\"}[15m]))",
                     "fullMetaSearch": false,
                     "hide": false,
                     "includeNullMetadata": true,
@@ -1080,7 +1080,7 @@
                     "useBackend": false
                 }
             ],
-            "title": "UDP Banned Requests (per sec)",
+            "title": "UDP4 Banned Requests (per sec)",
             "type": "timeseries"
         },
         {
@@ -1167,8 +1167,8 @@
             "targets": [
                 {
                     "disableTextWrap": false,
-                    "editorMode": "code",
-                    "expr": "sum(rate(udp_tracker_server_requests_received_total{job=\"tracker_metrics\"}[15m]))",
+                    "editorMode": "builder",
+                    "expr": "sum(rate(udp_tracker_server_requests_received_total{job=\"tracker_metrics\", server_binding_address_ip_family=\"inet\"}[15m]))",
                     "fullMetaSearch": false,
                     "hide": false,
                     "includeNullMetadata": true,
@@ -1184,7 +1184,7 @@
                     },
                     "disableTextWrap": false,
                     "editorMode": "builder",
-                    "expr": "sum(rate(udp_tracker_server_responses_sent_total{job=\"tracker_metrics\"}[15m]))",
+                    "expr": "sum(rate(udp_tracker_server_responses_sent_total{job=\"tracker_metrics\", server_binding_address_ip_family=\"inet\"}[15m]))",
                     "fullMetaSearch": false,
                     "hide": false,
                     "includeNullMetadata": true,
@@ -1390,7 +1390,7 @@
                     },
                     "disableTextWrap": false,
                     "editorMode": "builder",
-                    "expr": "sum(rate(udp_tracker_server_requests_aborted_total{job=\"tracker_metrics\"}[15m]))",
+                    "expr": "sum(rate(udp_tracker_server_requests_aborted_total{job=\"tracker_metrics\", server_binding_address_ip_family=\"inet\"}[15m]))",
                     "fullMetaSearch": false,
                     "hide": false,
                     "includeNullMetadata": true,
@@ -1401,7 +1401,7 @@
                     "useBackend": false
                 }
             ],
-            "title": "UDP aborted requests (per second)",
+            "title": "UDP4 aborted requests (per second)",
             "type": "timeseries"
         }
     ],
@@ -1412,13 +1412,13 @@
         "list": []
     },
     "time": {
-        "from": "now-6h",
+        "from": "now-3h",
         "to": "now"
     },
     "timepicker": {},
     "timezone": "browser",
     "title": "Torrust Live Demo Tracker (metrics)",
     "uid": "deogmiudufm68d",
-    "version": 32,
+    "version": 50,
     "weekStart": ""
 }


### PR DESCRIPTION
Graphs titles didn't match the filters.

- Some graphs didn't specify it's for UDP4.
- They didn't have a label to filter the IP family (inet), so inet6 was also included. That is not a problem yet becuase we haven't enabled inet6, but it would be when we [enabled it](https://github.com/torrust/torrust-demo/issues/52).